### PR TITLE
Add config option for theme CSS path

### DIFF
--- a/package.json
+++ b/package.json
@@ -70,6 +70,11 @@
           "type": "string",
           "default": "",
           "description": "The API key for the Lava Runner service. Get from /admin/security/rest-keys in your Rock instance."
+        },
+        "lavaRunner.themeCss": {
+          "type": "string",
+          "default": "/Themes/Rock/Styles/theme.css",
+          "description": "Relative path to your theme's CSS file. (Default: /Themes/Rock/Styles/theme.css)"
         }
       }
     },

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -42,6 +42,7 @@ export function activate(context: vscode.ExtensionContext) {
         const apiKey = config.get("apiKey") as string;
         const rootUrl = config.get("rootUrl") as string;
         const endpoint = config.get("endpoint") as string;
+        const themeCss = config.get("themeCss") as string;
 
         axios
           .post(`${rootUrl}${endpoint}`, content, {
@@ -58,7 +59,7 @@ export function activate(context: vscode.ExtensionContext) {
 
     <link rel="stylesheet" href="${rootUrl}/Themes/Rock/Styles/bootstrap.css" type="text/css" />
     
-    <link rel="stylesheet" href="${rootUrl}/Themes/ccbc/Styles/theme.css" type="text/css">
+    <link rel="stylesheet" href="${rootUrl}${themeCss}" type="text/css">
     <!-- Other head content -->
 </head>
 <body>


### PR DESCRIPTION
Currently, the theme CSS is hardcoded to `${rootUrl}/Themes/ccbc/Styles/theme.css`. This PR adds a config option to set that to point to a different theme.